### PR TITLE
#16 問い合わせ用モーダル追加とslack通知

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,6 +39,9 @@ class App extends React.Component {
           this.displayNextQuestions(nextQuestionId);
         }, 500);
         break;
+      case nextQuestionId === 'contact':
+        this.handleClickOpen();
+        break;
       case /^https:*/.test(nextQuestionId):
         const a = document.createElement('a');
         a.href = nextQuestionId;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,8 @@ class App extends React.Component {
       open: false,
     };
     this.selectAnswer = this.selectAnswer.bind(this);
+    this.handleClose = this.handleClose.bind(this);
+    this.handleClickOpen = this.handleClickOpen.bind(this);
   }
 
   displayNextQuestions = (nextQuestionId) => {
@@ -72,6 +74,14 @@ class App extends React.Component {
     }
   }
 
+  handleClickOpen = () => {
+    this.setState({ open: true });
+  };
+
+  handleClose = () => {
+    this.setState({ open: false });
+  };
+
   render() {
     return (
       <section className="c-section">
@@ -81,6 +91,7 @@ class App extends React.Component {
             answers={this.state.answers}
             select={this.selectAnswer}
           />
+          <FormDialog open={this.state.open} handleClose={this.handleClose} />
         </div>
       </section>
     );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import defaultDataset from './dataset';
 import './assets/styles/style.css';
-import { AnswersList, Chats } from './components';
+import { AnswersList, Chats, FormDialog } from './components';
 
 class App extends React.Component {
   constructor(props) {

--- a/src/components/Forms/FormDialog.jsx
+++ b/src/components/Forms/FormDialog.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import TextInput from './TextInput';
+
+export default class FormDialog extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      name: '',
+      email: '',
+      description: '',
+    };
+
+    this.inputName = this.inputName.bind(this);
+    this.inputEmail = this.inputEmail.bind(this);
+    this.inputDescription = this.inputDescription.bind(this);
+  }
+
+  inputName = (event) => {
+    this.setState({ name: event.target.value });
+  };
+
+  inputEmail = (event) => {
+    this.setState({ email: event.target.value });
+  };
+
+  inputDescription = (event) => {
+    this.setState({ description: event.target.value });
+  };
+
+  submitForm = () => {
+    const name = this.state.name;
+    const email = this.state.email;
+    const description = this.state.description;
+
+    const payload = {
+      text:
+        'お問い合わせがありました\n' +
+        'お名前:' +
+        name +
+        '\n' +
+        'Email:' +
+        email +
+        '\n' +
+        '問い合わせ内容\n' +
+        description,
+    };
+    const url =
+      'https://hooks.slack.com/services/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';
+    fetch(url, {
+      method: 'post',
+      body: JSON.stringify(payload),
+    }).then(() => {
+      alert('送信が完了しました。追ってご連絡します！');
+      this.setState({ name: '', email: '', description: '' });
+    });
+    return this.props.handleClose();
+  };
+
+  render() {
+    return (
+      <Dialog open={this.props.open} onClose={this.props.handleClose}>
+        <DialogTitle>お問合せフォーム</DialogTitle>
+        <DialogContent>
+          <TextInput
+            label={'お名前(必須)'}
+            multiline={false}
+            rows={1}
+            value={this.state.name}
+            type={'text'}
+            onChange={this.inputName}
+          />
+          <TextInput
+            label={'メールアドレス(必須)'}
+            multiline={false}
+            rows={1}
+            value={this.state.email}
+            type={'email'}
+            onChange={this.inputEmail}
+          />
+          <TextInput
+            label={'お問い合わせ内容(必須)'}
+            multiline={true}
+            rows={5}
+            value={this.state.description}
+            type={'text'}
+            onChange={this.inputDescription}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={this.props.handleClose} color="primary">
+            キャンセル
+          </Button>
+          <Button onClick={this.submitForm} color="primary">
+            送信する
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+}

--- a/src/components/Forms/TextInput.jsx
+++ b/src/components/Forms/TextInput.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import TextField from '@material-ui/core/TextField';
+
+const TextInput = (props) => {
+  return (
+    <TextField
+      fullWidth
+      label={props.label}
+      margin="dense"
+      multiline={props.multiline}
+      rows={props.rows}
+      value={props.value}
+      type={props.type}
+      onChange={props.onChange}
+    />
+  );
+};
+
+export default TextInput;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,3 +2,4 @@ export { default as AnswersList } from './AnswersList';
 export { default as Answer } from './Answer';
 export { default as Chats } from './Chats';
 export { default as Chat } from './Chat';
+export { default as FormDialog } from './Forms/FormDialog';


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
# 対応issue
Closes #16 
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
問い合わせ用モーダルを追加しslackと連携

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 問い合わせ用モーダルの為にFormDialogコンポーネントとTextInputコンポーネント作成
- 問い合わせ内容をSlackに通知する為に、テスト用のslackチャンネルにIncoming WebhookをSlackに入れた
- fetchを使用して、モーダル内容をslackに通知できる機能追加

# 補足
モーダル表示時にcomsoleエラーが出るが、調査中